### PR TITLE
Move importing  'paginator' macro from base.html.twig to index.html.twig

### DIFF
--- a/Symfony2/app/Resources/views/base.html.twig
+++ b/Symfony2/app/Resources/views/base.html.twig
@@ -1,4 +1,3 @@
-{% import "AcmeBlogBundle:Paginator:pagination.html.twig" as paginator %}
 {% if form is defined %}
     {% form_theme form 'AcmeBlogBundle:Form:form_row.html.twig' %}
 {% endif %}

--- a/Symfony2/src/Acme/BlogBundle/Resources/views/Public/index.html.twig
+++ b/Symfony2/src/Acme/BlogBundle/Resources/views/Public/index.html.twig
@@ -1,4 +1,5 @@
 {% extends 'AcmeBlogBundle:Public:layout.html.twig' %}
+{% import "AcmeBlogBundle:Paginator:pagination.html.twig" as paginator %}
 
 {% block bodyblog -%}
     <div class="col-md-8">


### PR DESCRIPTION
In the frontpage I get the follwing error

```
Neither the property "paginate" nor one of the methods "paginate()", "getpaginate()"/"ispaginate()"
 or "__call()" exist and have public access in class 
"__TwigTemplate_13eaed311a38a1640b494577d07088345ad2ece8428bae876aae65fe3cdcf2b1" in 
AcmeBlogBundle:Public:index.html.twig at line 41.
```

Test environment:
- PHP 7
- MySQL 5.5
- symfony/symfony: ~2.8.x-dev,
- twig/extensions: dev-master